### PR TITLE
jak1: cleanup / reorganization

### DIFF
--- a/goal_src/jak1/pc/features/autosplit.gc
+++ b/goal_src/jak1/pc/features/autosplit.gc
@@ -1,6 +1,6 @@
 ;;-*-Lisp-*-
 (in-package goal)
-(defun-extern draw-speedrun-settings (none))
+
 (define *autosplit-info-jak1* (new 'static 'autosplit-info-jak1))
 ;; Setup markers
 (charp<-string (-> *autosplit-info-jak1* end-marker) "end")
@@ -132,7 +132,6 @@
   (set! (-> *autosplit-info-jak1* int-jungle-fishgame) (if (task-closed? (game-task jungle-fishgame) (task-status need-introduction)) 1 0))
 
   ;; end
-  (draw-speedrun-settings)
   (none))
 
 

--- a/goal_src/jak1/pc/features/speedruns-h.gc
+++ b/goal_src/jak1/pc/features/speedruns-h.gc
@@ -1,23 +1,7 @@
 ;;-*-Lisp-*-
 (in-package goal)
 
+(define-extern speedrun-mode-update (function none))
 (define-extern speedrun-start-run (function none))
-
-
-(defun draw-speedrun-settings ()
-  "debug draw"
-(if (and (-> *pc-settings* speedrunner-mode?)(< (-> *autosplit-info-jak1* num-power-cells) 1))
-(begin
-(format *pc-temp-string* "OpenGOAL Version: ~S ~%Speedrun mode: ~A ~%Cutscene Skips ~A" *pc-settings-built-sha* (-> *pc-settings* speedrunner-mode?) (-> *pc-settings* cutscene-skips?))
-  (with-dma-buffer-add-bucket ((buf (-> (current-frame) global-buf))
-                                     (bucket-id debug-no-zbuf))
-          (draw-string-xy *pc-temp-string*
-                          buf
-                          0
-                          (* 200 (-> *video-parms* relative-y-scale))
-                          (font-color flat-yellow)
-                          (font-flags shadow kerning)))
-                          (clear *pc-temp-string*)))
-                          (none)
-                          )
+(define-extern speedrun-draw-settings (function none))
 

--- a/goal_src/jak1/pc/features/speedruns.gc
+++ b/goal_src/jak1/pc/features/speedruns.gc
@@ -1,6 +1,15 @@
 ;;-*-Lisp-*-
 (in-package goal)
 
+(defun speedrun-mode-update ()
+  "A per frame update for speedrunning related stuff"
+  (when (-> *pc-settings* speedrunner-mode?)
+    ;; Update auto-splitter
+    (update-autosplit-info-jak1)
+    ;; Draw info to the screen
+    (speedrun-draw-settings))
+  (none))
+
 (defun speedrun-start-run ()
   ;; randomize game id so the autosplitter knows to restart
   (update-autosplit-jak1-new-game)
@@ -16,4 +25,17 @@
   (close-specific-task! (game-task intro) (task-status need-resolution))
   ;; enable auto saving by default
   (set! (-> *setting-control* default auto-save) #t)
+  (none))
+
+(defun speedrun-draw-settings ()
+  "Draw speedrun related settings in the bottom left corner"
+  (when (and (-> *pc-settings* speedrunner-mode?)
+             (< (-> *autosplit-info-jak1* num-power-cells) 1))
+    (with-dma-buffer-add-bucket ((buf (-> (current-frame) global-buf))
+                                      (bucket-id debug-no-zbuf))
+      (draw-string-xy (string-format "OpenGOAL Version: ~S ~%Speedrun mode: ~A ~%Cutscene Skips ~A"
+                                     *pc-settings-built-sha*
+                                     (-> *pc-settings* speedrunner-mode?)
+                                     (-> *pc-settings* cutscene-skips?))
+                      buf 0 (- 224 (* 8 4)) (font-color flat-yellow) (font-flags shadow kerning))))
   (none))

--- a/goal_src/jak1/pc/pckernel.gc
+++ b/goal_src/jak1/pc/pckernel.gc
@@ -327,8 +327,8 @@
 
   ;; update auto-splitter info
   (when (-> *pc-settings* speedrunner-mode?)
-    (with-profiler "autosplit-update-jak1"
-      (update-autosplit-info-jak1)))
+    (with-profiler "speedrun-update-jak1"
+      (speedrun-mode-update)))
 
   (when (not (-> obj use-vis?))
     (set! (-> *video-parms* relative-x-scale) (-> obj aspect-ratio-reciprocal))


### PR DESCRIPTION
- Moved implementation out of the "header" files
- Changed the entry point to be a function defined in `speedrun.gc` which updates the autosplitter and calls the draw function for this stuff
- general code cleanup / formatting